### PR TITLE
relax moment dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"url": "https://github.com/SeverinDK/moment-timer"
 	},
 	"dependencies": {
-		"moment": "latest"
+		"moment": ">= 1.6.0"
 	},
 	"authors": [
 		"Søren Ernst <some12thing@gmail.com>"


### PR DESCRIPTION
When using webpack, `moment-timer` can cause multiple copies of `moment` to be bundled with your app if it's depending on a version other than `moment@latest`.

This results in the following error
```
moment.duration(...).timer is not a function
```
Because `moment-timer` will end up referencing it's own copy of `moment` (`/node_modules/moment-timer/node_modules/moment/moment.js`) rather than the one the rest of the app is using (`./node_modules/moment/moment.js`).

This PR relaxes the dependency range for `moment-timer` so that it has a better chance of being satisfied by the version an app is already using. I chose `1.6.0` as the minimum because [that appears to be the version](https://momentjs.com/docs/#/durations/creating/) `duration` was added, but let me know if you think it should be something else.