### PR TITLE
Possible fix for moment.duration(...).timer is not a function

### DIFF
--- a/lib/moment-timer.js
+++ b/lib/moment-timer.js
@@ -141,9 +141,6 @@
         return this.started;
     }
 
-    // define internal moment reference
-    var moment;
-
     if (typeof require === "function") {
         try { moment = require('moment'); }
         catch (e) {}


### PR DESCRIPTION
Variable moment is already defined as a function parameter.

Example:

```javascript
let moment = require("moment");
require("moment-timer");

let timer = new moment.duration(30, "seconds").timer(
    {
        loop: false,
        start: true
    },
    console.log("timer ran");
);
```

Error:
```
Error in created hook: "TypeError: (new moment.duration(...)).timer is not a function"
```

This works with webpack, not sure it works when loaded via a browser script tag.