### PR TITLE
Add CDN usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ npm install moment-timer
 bower install moment-timer
 ```
 
+### CDN
+```
+<script src="https://cdn.jsdelivr.net/npm/moment-timer/lib/moment-timer.js"></script>
+```
+
 ### Browser
 ```
 <script src="path/to/moment-timer.js"></script>


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/package/npm/moment-timer) to your readme to make it easier to use. jsDelivr is the fastest opensource CDN available and built specifically for production usage.