### PR TITLE
Implement immediate execution in base

### DIFF
--- a/lib/moment-timer.js
+++ b/lib/moment-timer.js
@@ -22,14 +22,17 @@
         this.endTick;
 
         if (attributes.start) {
-            if (attributes.wait > 0) {
-                var self = this;
-                setTimeout(function () {
-                    if (attributes.executeAfterWait) {
+            if (attributes.executeAfterWait) {
+                if (attributes.wait > 0) {
+                    var self = this;
+                    setTimeout(function () {
                         callback();
-                    }
-                    self.start();
-                }, attributes.wait);
+                        self.start();
+                    }, attributes.wait);
+                } else {
+                    callback();
+                    this.start();
+                }
             } else {
                 this.start();
             }


### PR DESCRIPTION
If the wait period is zero or omitted, but the execute-after-wait flag is set, execute the callback immediately before starting the timer/interval.