### PR TITLE
Implement executeImmediately attribute

### DIFF
--- a/lib/moment-timer.js
+++ b/lib/moment-timer.js
@@ -22,6 +22,9 @@
         this.endTick;
 
         if (attributes.start) {
+            if (attributes.executeImmediately) {
+                callback();
+            }
             if (attributes.wait > 0) {
                 var self = this;
                 setTimeout(function () {


### PR DESCRIPTION
If the executeImmediately attribute is set _and_ the timer is auto-started, run the callback immediately before continuing.